### PR TITLE
Issue #13 - Refined the "Take new Cig" Function

### DIFF
--- a/addons/murshun_cigs/functions/fn_preInit.sqf
+++ b/addons/murshun_cigs/functions/fn_preInit.sqf
@@ -295,10 +295,11 @@ murshun_cigs_fnc_take_cig_from_pack = {
     [_player, "murshun_cigs_unwrap"] call murshun_cigs_playSound;
 
     if (goggles _player == "") then {
-        _player addItem "murshun_cigs_cig0";
+        _player addGoggles "murshun_cigs_cig0";
     } else {
         if (hmd _player == "") then {
             _player addItem "murshun_cigs_cig0_nv";
+            _player assignItem "murshun_cigs_cig0_nv";            
         } else {
             _player addItem "murshun_cigs_cig0";
         };


### PR DESCRIPTION
#13 

When taking a new Cigarette from the box...
-> If Face is free, adds cigs to the facewear slot
else
-> If NVG Slot is free, add NVG Version and assign to NVG Slot
else
-> Put normal Cig in Inventory

Tested in Singleplayer Editor, worked fine.